### PR TITLE
Add architecture variable to Lambda Function

### DIFF
--- a/modules/function/main.tf
+++ b/modules/function/main.tf
@@ -58,6 +58,7 @@ resource "aws_cloudwatch_log_group" "this" {
 }
 
 resource "aws_lambda_function" "this" {
+    architectures = [var.architecture]
     function_name = "${var.family}-${local.safe_name}-${local.env_name}"
     role = aws_iam_role.this.arn
     package_type = "Image"

--- a/modules/function/variables.tf
+++ b/modules/function/variables.tf
@@ -10,6 +10,11 @@ variable "name" {
     type = string
 }
 
+variable "architecture" {
+    type = string
+    default = "x86_64"
+}
+
 variable "memory" {
     type = number
     default = 128


### PR DESCRIPTION
This PR adds the architecture variable to the function module.

Needed for choosing to deploy between x86 and arm